### PR TITLE
Refactor database client and add stale test run cleanup job

### DIFF
--- a/db/dbClient.ts
+++ b/db/dbClient.ts
@@ -1,0 +1,12 @@
+import { Client } from "pg"
+
+const PG_DEFAULT_PORT = 5432
+
+export const client = new Client({
+    host: process.env.DB_HOST || "127.0.0.1",
+    port: Number(process.env.DB_PORT) || PG_DEFAULT_PORT,
+    database: process.env.DB_NAME || "jtl_report",
+    user: process.env.DB_USER || "postgres",
+    password: process.env.DB_PASS,
+    max: 60,
+})

--- a/index.ts
+++ b/index.ts
@@ -12,6 +12,10 @@ const bree = new Bree({
             name: "test-run-housekeeping",
             interval: "every 6 hours",
         },
+        {
+            name: "stale-test run-housekeeping",
+            interval: "every 1 hour",
+        },
     ],
 })
 

--- a/jobs/stale-test run-housekeeping.ts
+++ b/jobs/stale-test run-housekeeping.ts
@@ -1,0 +1,29 @@
+import { client } from "../db/dbClient"
+
+const DELETE_QUERY =
+    `DELETE FROM jtl.items WHERE id IN (
+        SELECT id FROM jtl.items items WHERE items.report_status = 'in_progress'::report_status 
+        AND upload_time < now() - interval '8 hour'
+        ) RETURNING id;
+`
+
+client.connect((err: { stack: unknown }) => {
+    if (err) {
+        console.error("Connection error", err.stack)
+        throw err
+    } else {
+        console.log("Connected to DB")
+    }
+})
+
+client.query(DELETE_QUERY, (err, res) => {
+    if (err) throw err
+    if (res.rows.length > 0) {
+        console.log(`Deleted the following stale ${res.rows.length} test(s): ` + JSON.stringify(res.rows))
+    } else {
+        console.log("No stale test runs found, exiting.")
+    }
+    client.end()
+    process.exit(0)
+
+})

--- a/jobs/test-run-housekeeping.ts
+++ b/jobs/test-run-housekeeping.ts
@@ -1,6 +1,5 @@
-import { Client } from "pg"
+import { client } from "../db/dbClient"
 
-const PG_DEFAULT_PORT = 5432
 const DELETE_QUERY = `DELETE FROM jtl.items WHERE id IN (
         SELECT it.id FROM jtl.items it LEFT JOIN jtl.scenario sc on it.scenario_id = sc.id
         WHERE sc.keep_test_runs_period > 0
@@ -8,14 +7,6 @@ const DELETE_QUERY = `DELETE FROM jtl.items WHERE id IN (
         AND it.base IS NOT TRUE) 
     RETURNING id, start_time`
 
-export const client = new Client({
-    host: process.env.DB_HOST || "127.0.0.1",
-    port: Number(process.env.DB_PORT) || PG_DEFAULT_PORT,
-    database: process.env.DB_NAME || "jtl_report",
-    user: process.env.DB_USER || "postgres",
-    password: process.env.DB_PASS,
-    max: 60,
-})
 
 client.connect((err: { stack: unknown }) => {
     if (err) {


### PR DESCRIPTION
The database client setup has been refactored out to a separate module named dbClient in the db directory. Additionally, a new cleanup job called 'stale-test run-housekeeping' has been implemented to delete stale test runs, scheduled to run every 1 hour. This cleanup job targets test runs which are marked as in-progress and have an upload time of more than 8 hours ago.